### PR TITLE
Initial webapp2 plugin

### DIFF
--- a/smore/apispec/core.py
+++ b/smore/apispec/core.py
@@ -32,12 +32,6 @@ class Path(object):
             raise APISpecError(
                 'One or more HTTP methods are invalid: {0}'.format(", ".join(invalid))
             )
-        # Reject invalid operations definitions
-        for method, operation in iteritems(operations):
-            if len(operation.get('responses', {})) == 0:
-                raise APISpecError(
-                    'One or more Responses are required for method {0}'.format(method)
-                )
         self.operations = operations
 
     def to_dict(self):

--- a/smore/ext/webapp2.py
+++ b/smore/ext/webapp2.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""
+.. module:: webapp2
+   :synopsis: Automatic documentation from your webapp2 project
+
+The :mod:`smore.ext.webapp2 <webapp2>` module generates swagger path objects from your routes
+
+"""
+from __future__ import absolute_import
+
+import webapp2
+from marshmallow.compat import iteritems
+from smore.apispec import Path
+from smore.apispec.exceptions import APISpecError
+from smore.apispec import utils
+
+
+def path_from_route(spec, route, operations=None, **kwargs):
+    """Creates a :class:`smore.apispec.Path` object based off of a :class:`webapp2.Route` and their subclasses
+
+    :param smore.apispec.APISpec spec:
+    :param webapp2.Route route:
+    :param kwargs:
+    :return: The generated :class:`Path <smore.apispec.Path>` object
+    :rtype: smore.apispec.Path
+    """
+    # make sure route.reverse_template is lazy loaded
+    getattr(route, 'regex', None)
+    path = route.reverse_template.replace('%(', '{').replace(')s', '}')
+    methods = route.methods if route.methods else ['GET', 'POST', 'PUT', 'DELETE']
+    merge_ops = {method.lower(): {} for method in methods}
+    for method, details in iteritems(operations or {}):
+        if method not in merge_ops:
+            raise APISpecError("Method {0} is not handled by route {0}".format(method, path))
+        merge_ops[method].update(details)
+    handler = route.handler
+    router = webapp2.get_app().router
+    if isinstance(handler, basestring):
+        if handler not in router.handlers:
+            router.handlers[handler] = handler = webapp2.import_string(handler)
+        else:
+            handler = router.handlers[handler]
+    for method, details in iteritems(merge_ops):
+        handler_method = getattr(handler, route.handler_method or method.lower().replace('-', '_'), None)
+        docops = utils.load_operations_from_docstring(getattr(handler_method, '__doc__', ''))
+        # Merge in any `method`: yaml subsection
+        if docops and docops.get(method, None):
+            details.update(docops.get(method))
+    path = Path(path=path, operations=merge_ops)
+    return path
+
+
+def setup(spec):
+    """Register plugin with the :class:`smore.apispec.APISpec`
+
+    :param smore.apispec.APISpec spec: The APISpec instance the plugin will register data onto
+    """
+    spec.register_path_helper(path_from_route)

--- a/tests/apispec/test_core.py
+++ b/tests/apispec/test_core.py
@@ -118,7 +118,7 @@ class TestExtensions:
     def test_setup_plugin(self, mock_setup, spec):
         spec.setup_plugin(self.DUMMY_PLUGIN)
         assert self.DUMMY_PLUGIN in spec.plugins
-        mock_setup.assert_called_once
+        mock_setup.assert_called_once()
         spec.setup_plugin(self.DUMMY_PLUGIN)
         assert mock_setup.call_count == 1
 

--- a/tests/apispec/test_ext_webapp2.py
+++ b/tests/apispec/test_ext_webapp2.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+import pytest
+import sys
+
+PY2 = int(sys.version[0]) == 2
+
+pytestmark = pytest.mark.skipif(not PY2, reason='webapp2 is only compatible with Python 2')
+
+from smore.apispec import APISpec
+
+if PY2:
+    # everything should be skipped via `pytestmark` here so it is OK
+    import webapp2
+    from webapp2_extras import routes
+
+
+    class MainPage(webapp2.RequestHandler):
+        def get(self, *args, **kwargs):
+            self.response.write('Hello from GET!')
+
+        def post(self, *args, **kwargs):
+            self.response.write('Hello from POST!')
+
+        def put(self, *args, **kwargs):
+            self.response.write('Hello from PUT!')
+
+        def delete(self, *args, **kwargs):
+            self.response.write('Hello from DELETE!')
+
+        def patch(self, *args, **kwargs):
+            self.response.write('Hello from PATCH!')
+
+        def get_with_docstring(self, *args, **kwargs):
+            """A greeting endpoint.
+
+            ---
+            get:
+                description: get a greeting
+                responses:
+                    200:
+                        description: Greets you
+
+            post:
+                description: post a greeting
+                responses:
+                    200:
+                        description:some data
+
+            foo:
+                description: not a valid operation
+                responses:
+                    200:
+                        description:
+                            more junk
+            """
+            self.response.write('Hello from GET docstring!')
+
+
+@pytest.fixture()
+def spec():
+    return APISpec(
+        title='Swagger Petstore',
+        version='1.0.0',
+        description='This is a sample Petstore server.  You can find out more '
+        'about Swagger at <a href=\"http://swagger.wordnik.com\">http://swagger.wordnik.com</a> '
+        'or on irc.freenode.net, #swagger.  For this sample, you can use the api '
+        'key \"special-key\" to test the authorization filters',
+        plugins=[
+            'smore.ext.webapp2'
+        ]
+    )
+
+
+@pytest.fixture()
+def app():
+    _app = webapp2.WSGIApplication([
+        routes.PathPrefixRoute('/prefix', [
+            # all routes go here
+            webapp2.Route(r'/path/<course_id>', MainPage, methods=['GET']),
+            webapp2.Route(r'/users/<user_id:\d+>/setting/<setting_id:\w\d+>', MainPage),
+        ]),
+        webapp2.Route(r'/1', MainPage),
+        webapp2.Route(r'/2', MainPage, methods=['POST']),
+        webapp2.Route(r'/3', MainPage, methods=['DELETE', 'GET'])
+    ], debug=True)
+    # set up app and request for testing
+    request = webapp2.Request.blank('/')
+    _app.set_globals(app=_app, request=request)
+    return _app
+
+
+class TestPathHelpers:
+
+    def test_path_from_view(self, app, spec):
+        route = webapp2.Route(r'/hello', MainPage, methods=['GET'])
+        spec.add_path(route=route)
+        assert '/hello' in spec._paths
+        assert 'get' in spec._paths['/hello']
+        assert spec._paths['/hello']['get'] == {}
+
+    def test_path_with_multiple_methods(self, app, spec):
+        route = webapp2.Route(r'/hello', MainPage, methods=['GET', 'POST'])
+        spec.add_path(route=route, operations=dict(
+            get={'description': 'get a greeting', 'responses': {'200': '..params..'}},
+            post={'description': 'post a greeting', 'responses': {'200': '..params..'}}
+        ))
+
+        get_op = spec._paths['/hello']['get']
+        post_op = spec._paths['/hello']['post']
+        assert get_op['description'] == 'get a greeting'
+        assert post_op['description'] == 'post a greeting'
+
+    def test_integration_with_docstring_introspection(self, app, spec):
+        route = webapp2.Route(r'/hello', MainPage, methods=['GET', 'POST'], handler_method='get_with_docstring')
+        spec.add_path(route=route)
+        get_op = spec._paths['/hello']['get']
+        post_op = spec._paths['/hello']['post']
+        assert get_op['description'] == 'get a greeting'
+        assert post_op['description'] == 'post a greeting'
+        assert 'foo' not in spec._paths['/hello']
+
+    def test_path_is_translated_to_swagger_template(self, app, spec):
+        route = webapp2.Route(r'/hello/<name:\d+>', MainPage, methods=['GET', 'POST'])
+        spec.add_path(route=route)
+
+        assert '/hello/{name}' in spec._paths
+
+    def test_route_types_can_be_translated(self, app, spec):
+        routes = set(r for route in app.router.match_routes for r in route.get_routes())
+        for route in routes:
+            spec.add_path(route=route)
+        assert len(spec._paths) == len(routes)
+        assert '/prefix/path/{course_id}' in spec._paths
+        assert '/prefix/users/{user_id}/setting/{setting_id}' in spec._paths
+        assert '/1' in spec._paths
+        assert '/2' in spec._paths
+        assert '/3' in spec._paths


### PR DESCRIPTION
So far all we support is auto-generating paths from routes. That may be all we need.

Removed check for the required `responses` key for the Path operations so that definitions can come from multiple sources before the final json schema is created. The check will need to be deferred to the final-final-final json output?